### PR TITLE
Fix unknown typo

### DIFF
--- a/easy_chi2_fun.r
+++ b/easy_chi2_fun.r
@@ -180,7 +180,7 @@ GetAlternateAlleles <- function(refNuc, observed) {
   } else if(refNuc == "D"){
     altNucleotides <- c(TRUE, TRUE, TRUE, TRUE, TRUE, FALSE)
   } else {
-    stop("Freq. Estimation: Uknown character used as Ref. nucleotide")
+    stop("Freq. Estimation: Unknown character used as Ref. nucleotide")
   }
   #mark the non-existing nuc/allele as not being alternate
   for (i in 1:6) {
@@ -260,7 +260,7 @@ GetAllelesLabel <- function(nucPosition, refNucleotide, As, Cs, Gs, Ts, Is, Ds) 
     refNucChar <- "D"
     altNucleotides <- c(TRUE, TRUE, TRUE, TRUE, TRUE, FALSE)
   } else {
-    stop("Freq. Estimation: Uknown character used as Ref. nucleotide")
+    stop("Freq. Estimation: Unknown character used as Ref. nucleotide")
   }
   
   for (i in 1:6) {


### PR DESCRIPTION
## Summary
- fix spelling in `easy_chi2_fun.r` error messages

## Testing
- `Rscript -e "source('easy_chi2_fun.r')"`

------
https://chatgpt.com/codex/tasks/task_e_684b8c9a443883218029f287493c8b5f